### PR TITLE
Created ContentBlock Component

### DIFF
--- a/src/components/AboutCases.vue
+++ b/src/components/AboutCases.vue
@@ -1,0 +1,41 @@
+<template>
+  <v-container id="about-case">
+    <div
+    v-for="(item, index) in cases"
+    :key="index">
+      <ContentBlock :data="item" :iterator="index"/>
+      <hr v-if='index !== cases.length - 1'/>
+    </div>
+  </v-container>
+</template>
+
+<script>
+import ContentBlock from './ContentBlock'
+
+export default {
+  data () {
+    return {
+      cases: [
+        {
+          title: 'Case Title v2',
+          contents: [
+            { contentTitle: 'First Point Title', contentText: 'Here is my content' },
+            { contentTitle: 'Second Point Title', contentText: 'Here is my second content' }
+          ],
+          image: 'https://www.w3schools.com/images/colorpicker.gif'
+        }
+      ]
+    }
+  },
+  components: {
+    ContentBlock
+  }
+}
+</script>
+
+<style scoped>
+#about-case {
+  margin: 0;
+  padding: 0;
+}
+</style>

--- a/src/components/ContentBlock.vue
+++ b/src/components/ContentBlock.vue
@@ -1,0 +1,84 @@
+<template>
+  <div id="content-block">
+    <div>
+      <h2 class="content-title text-xs-center">{{data.title}}</h2>
+      <!-- First Layout has the option to alternate the side the image appears on -->
+      <v-layout row wrap align-center>
+        <v-flex xs3 text-xs-center v-if='iterator !== undefined && (iterator) % 2' >
+          <img :src='data.image' alt="cat">
+        </v-flex>
+        <v-flex xs9>
+          <div
+          v-for='(content, content_index) in data.contents'
+          :key='content_index'>
+            <ContentParagraphs
+            :contentTitle='content.contentTitle'
+            :contentText='content.contentText'/>
+          </div>
+        </v-flex>
+        <v-flex xs3 text-xs-center v-if='iterator === undefined || (iterator + 1) % 2' >
+          <img :src='data.image' alt="cat">
+        </v-flex>
+      </v-layout>
+    </div>
+    <div v-if='data.image === undefined'>
+      <!-- Second Layout is without image, contents will be displayed side by side if there are 2 or 3-->
+      <v-layout v-if='contents.length == 2'>
+        <v-flex
+        v-for='(content, content_index) in data.contents'
+        :key='content_index'
+        xs6>
+          <ContentParagraphs
+          :contentTitle='content.contentTitle'
+          :contentText='content.contentText'/>
+        </v-flex>
+      </v-layout>
+      <v-layout v-else-if='contents.length == 3'>
+        <v-flex
+        v-for='(content, content_index) in data.contents'
+        :key='content_index'
+        xs4>
+          <ContentParagraphs
+          :contentTitle='content.contentTitle'
+          :contentText='content.contentText'/>
+        </v-flex>
+      </v-layout row wrap align-center>
+      <v-layout v-else>
+        <v-flex xs12>
+          <div
+          v-for='(content, content_index) in data.contents'
+          :key='content_index'>
+            <ContentParagraphs
+            :contentTitle='content.contentTitle'
+            :contentText='content.contentText'/>
+          </div>
+        </v-flex>
+      </v-layout>
+    </div>
+  </div>
+</template>
+
+<script>
+import ContentParagraphs from './ContentParagraphs'
+
+export default {
+  props: {
+    data: {
+      title: { type: String }, //Content title
+      contents: { type: Object }, //Array of content objects with attributes "contentTitle" and "contentText"
+      image: { type: String } //Accompanying image
+    },
+    iterator: { type: Number } //If odd, image shows on left. Even, right.
+  },
+  components: {
+    ContentParagraphs
+  }
+}
+</script>
+
+<style scoped>
+.content-paragraph {
+  margin: 0;
+  padding: 0;
+}
+</style>

--- a/src/components/ContentParagraphs.vue
+++ b/src/components/ContentParagraphs.vue
@@ -1,0 +1,25 @@
+<template>
+  <div id="content-block">
+    <p class="content-paragraph pt-4">
+      <strong class="content-title">{{contentTitle}}</strong>
+      <br />
+      <span class="content-text">{{contentText}}</span>
+    </p>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    contentTitle: { type: String },
+    contentText: { type: String }
+  }
+}
+</script>
+
+<style scoped>
+.content-paragraph {
+  margin: 0;
+  padding: 0;
+}
+</style>

--- a/src/components/ServiceTypes.vue
+++ b/src/components/ServiceTypes.vue
@@ -1,0 +1,63 @@
+<template>
+  <v-container id="service-types">
+    <v-layout
+        text-xs-center
+        wrap
+    >
+      <v-flex xs12>
+          <p class="title-main">
+              Services
+          </p>
+      </v-flex>
+    </v-layout>
+    <v-card>
+      <div
+      v-for="(service, index) in services"
+      :key="index"
+      class="service-listing px-4 pt-4">
+        <ContentBlock :data="service"/>
+        <br />
+        <hr v-if='index !== services.length - 1'/>
+      </div>
+    </v-card>
+  </v-container>
+</template>
+
+<script>
+import ContentBlock from './ContentBlock'
+
+export default {
+  data () {
+    return {
+      services: [
+        {
+          title: 'Service Title',
+          contents: [
+            { contentTitle: 'First Point Title', contentText: 'Here is my content' },
+            { contentTitle: 'Second Point Title', contentText: 'Here is my second content' }
+          ],
+          image: 'https://www.w3schools.com/images/colorpicker.gif'
+        },
+        {
+          title: 'Second Service Title',
+          contents: [
+            { contentTitle: 'First Point Title', contentText: 'Here is my content' },
+            { contentTitle: 'Second Point Title', contentText: 'Here is my second content' }
+          ],
+          image: 'https://www.w3schools.com/images/colorpicker.gif'
+        }
+      ]
+    }
+  },
+  components: {
+    ContentBlock
+  }
+}
+</script>
+
+<style scoped>
+.service-listing {
+  margin: 10;
+  padding: 10;
+}
+</style>

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -5,13 +5,15 @@
         wrap
         class="pt-5"
     >
-        <v-flex xs12>
-            <p class="title-main">
-                About Us
-            </p>
-        </v-flex>
+      <v-flex xs12>
+          <p class="title-main">
+              About Us
+          </p>
+      </v-flex>
+      <v-card class="main-card">
         <v-flex xs12 class="pt-4">
           <div class="content">
+
             <p>
                 Movvz, Forefront of modern delivery network.
                 <br/><br/>
@@ -23,12 +25,29 @@
                 On top of regular deliveries, our system also ensures user safety and privacy between buyers and sellers on used marketplaces like Facebook Marketplace, Craigslist, OfferUp, and LetGo.
             </p>
           </div>
+          <span class="content">
+            <AboutCases />
+          </span>
         </v-flex>
+      </v-card>
     </v-layout>
   </div>
 </template>
 
+<script>
+import AboutCases from '../components/AboutCases'
+
+export default {
+  components: {
+    AboutCases
+  }
+}
+</script>
+
 <style scoped>
+.main-card{
+  padding: 80px 112px
+}
 .content {
   text-align: left;
   padding: 0 100px;

--- a/src/views/Services.vue
+++ b/src/views/Services.vue
@@ -1,15 +1,22 @@
 <template>
   <div id="services">
-    <Pricing />
+    <span>
+      <Pricing />
+    </span>
+    <div>
+      <Services />
+    </div>
   </div>
 </template>
 
 <script>
 import Pricing from '../components/Pricing'
+import Services from '../components/ServiceTypes'
 
 export default {
   components: {
-    Pricing
+    Pricing,
+    Services
   }
 }
 </script>


### PR DESCRIPTION
Created ContentBlock Component inspired by firebase.google.com/use-cases. Added to Services and About pages.

props:
  --Data
    --title - Main title of content block
    --contents
      --contentTitle - Sub-title of a content section
      --contentText - Text of a content section
    --image - an image to display alongside entire content block. If none, and contents.length is less than 4, content sections will be displayed side by side
  --Iterator - Optional parameter to flip image to left or right side of text.

There is only test data in the components.

Data object is in the following format:
export default {
  data () {
    return {
      cases: [
        {
          title: 'Case Title v2',
          contents: [
            { contentTitle: 'First Point Title', contentText: 'Here is my content' },
            { contentTitle: 'Second Point Title', contentText: 'Here is my second content' }
          ],
          image: 'https://www.w3schools.com/images/colorpicker.gif'
        }
      ]
    }
  },
  components: {
    ContentBlock
  }
}